### PR TITLE
[#54] HttpResponse 읽을 수 없는 이슈 수정

### DIFF
--- a/src/main/java/dev/flab/studytogether/filter/LoggingFilter.java
+++ b/src/main/java/dev/flab/studytogether/filter/LoggingFilter.java
@@ -23,7 +23,9 @@ public class LoggingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
-        //request, response 캐시 가능하도록 wrapping
+        /*
+        request, response 캐시 가능하도록 wrapping
+        * */
         ContentCachingRequestWrapper httpServletRequest =
                 new ContentCachingRequestWrapper((HttpServletRequest) request);
         ContentCachingResponseWrapper httpServletResponse =
@@ -33,7 +35,12 @@ public class LoggingFilter implements Filter {
 
         String reqContentJSon = LoggingUtil.makeLoggingRequestJSON(httpServletRequest);
         String resContent = new String(httpServletResponse.getContentAsByteArray());
-        
+
+        /*
+        Body 값을 읽기 위해 복사해놓는 과정 필요
+        * */
+        httpServletResponse.copyBodyToResponse();
+
         log.info("request : {}", reqContentJSon);
         //response 추후 수정 예정
         log.info("response : {}", resContent);


### PR DESCRIPTION
- 응답을 두 번 읽을 수 없어 발생한 이슈로 인해 HTTP 응답이 반환되지 않는 문제 수정
- LoggingFilter에서 응답을 두 번 읽을 수 없는 제약 조건을 고려하여
  응답 본문을 복사하여 저장하는 프로세스 추가
