### PR TITLE
[#64] ExceptionController 수정

### DIFF
--- a/src/main/java/dev/flab/studytogether/handler/ExceptionController.java
+++ b/src/main/java/dev/flab/studytogether/handler/ExceptionController.java
@@ -2,7 +2,7 @@ package dev.flab.studytogether.handler;
 
 import dev.flab.studytogether.exception.BadRequestException;
 import dev.flab.studytogether.exception.NotFoundException;
-import dev.flab.studytogether.response.SingleApiResponse;
+import dev.flab.studytogether.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -13,13 +13,13 @@ public class ExceptionController {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BadRequestException.class)
-    public SingleApiResponse<Void> badRequestExceptionHandle(BadRequestException e) {
-        return SingleApiResponse.badRequest(e.getMessage());
+    public ApiResponse<Void> badRequestExceptionHandle(BadRequestException e) {
+        return ApiResponse.badRequest(e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NotFoundException.class)
-    public SingleApiResponse<Void> notFoundExceptionHandle(NotFoundException e) {
-        return SingleApiResponse.notFound(e.getMessage());
+    public ApiResponse<Void> notFoundExceptionHandle(NotFoundException e) {
+        return ApiResponse.notFound(e.getMessage());
     }
 }


### PR DESCRIPTION
- BadRequestException 및 NotFoundException에 대한 예외 처리 핸들러의 반환 타입을 SingleApiResponse에서 ApiResponse로 변경