### PR TITLE
[#71] StudyRoomApiController 테스트 코드 추가

### DIFF
--- a/src/main/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiController.java
+++ b/src/main/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
 import javax.servlet.http.HttpSession;
 import java.util.List;
 
@@ -28,26 +29,28 @@ public class StudyRoomApiController {
     @PostMethodLog
     @Operation(summary = "Create room", description = "스터디룸 생성")
     @ResponseStatus(HttpStatus.OK)
-    public StudyRoomResponse createRoom(RoomCreateRequest requestDto, HttpSession httpSession) {
+    public StudyRoomResponse createRoom(@RequestBody RoomCreateRequest requestDto, HttpSession httpSession) {
         int memberSeqId = getMemberSequenceId(httpSession);
         StudyRoom studyRoom = studyRoomService.createRoom(requestDto.getRoomName(), requestDto.getTotal(), memberSeqId);
 
         return StudyRoomResponse.from(studyRoom);
     }
-    @GetMapping("/api/v1/rooms/{roomId}")
+    @GetMapping("/api/v1/rooms")
     @Operation(summary = "Enter Room", description = "스터디룸 입장")
     @ResponseStatus(HttpStatus.OK)
-    public StudyRoomResponse enterRoom(@PathVariable int roomId, HttpSession httpSession){
+    public StudyRoomResponse enterRoom(@RequestParam(name = "roomId") int roomId,
+                                       HttpSession httpSession){
         int memberSeqId = getMemberSequenceId(httpSession);
         StudyRoom studyRoom = studyRoomService.enterRoom(roomId, memberSeqId);
 
         return StudyRoomResponse.from(studyRoom);
     }
 
-    @DeleteMapping("/api/v1/rooms/{roomId}")
+    @DeleteMapping("/api/v1/rooms")
     @Operation(summary = "Exit Room", description = "스터디룸 퇴장")
     @ResponseStatus(HttpStatus.OK)
-    public StudyRoomResponse exitRoom(@PathVariable int roomId, HttpSession httpSession){
+    public StudyRoomResponse exitRoom(@RequestParam(name = "roomId") int roomId,
+                                      HttpSession httpSession){
         int memberSeqId = getMemberSequenceId(httpSession);
         StudyRoom studyRoom = studyRoomExitService.exitRoom(roomId, memberSeqId);
 
@@ -75,9 +78,9 @@ public class StudyRoomApiController {
                 .toList();
     }
 
-    @GetMapping("/api/v1/rooms/info/{roomId}")
+    @GetMapping("/api/v1/rooms/info")
     @ResponseStatus(HttpStatus.OK)
-    public StudyRoomResponse getRoomInfo(@PathVariable int roomId) {
+    public StudyRoomResponse getRoomInfo(@RequestParam(name = "roomId") int roomId) {
         StudyRoom studyRoom = studyRoomService.getRoomInformation(roomId);
         return StudyRoomResponse.from(studyRoom);
     }

--- a/src/main/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiController.java
+++ b/src/main/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiController.java
@@ -23,7 +23,6 @@ public class StudyRoomApiController {
 
     private final StudyRoomService studyRoomService;
     private final StudyRoomExitService studyRoomExitService;
-    private final HttpSession httpSession;
 
     @PostMapping("/api/v1/rooms")
     @PostMethodLog
@@ -85,7 +84,7 @@ public class StudyRoomApiController {
 
 
     private int getMemberSequenceId(HttpSession httpSession) {
-        return SessionUtil.getLoginMemebrSeqId(httpSession);
+        return SessionUtil.getLoginMemberSequenceId(httpSession);
     }
 
 }

--- a/src/main/java/dev/flab/studytogether/domain/room/dto/RoomCreateRequest.java
+++ b/src/main/java/dev/flab/studytogether/domain/room/dto/RoomCreateRequest.java
@@ -1,10 +1,13 @@
 package dev.flab.studytogether.domain.room.dto;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@Data
+@AllArgsConstructor
+@Getter
 public class RoomCreateRequest {
+    private String roomName;
+    private int total;
 
-    private final String roomName;
-    private final int total;
+    private RoomCreateRequest() {}
 }

--- a/src/test/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiControllerTest.java
+++ b/src/test/java/dev/flab/studytogether/domain/room/controller/StudyRoomApiControllerTest.java
@@ -1,0 +1,383 @@
+package dev.flab.studytogether.domain.room.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import dev.flab.studytogether.domain.room.dto.RoomCreateRequest;
+import dev.flab.studytogether.domain.room.entity.StudyRoom;
+import dev.flab.studytogether.domain.room.service.StudyRoomExitService;
+import dev.flab.studytogether.domain.room.service.StudyRoomService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+class StudyRoomApiControllerTest {
+    @InjectMocks
+    private StudyRoomApiController studyRoomApiController;
+    @Mock
+    private StudyRoomService studyRoomService;
+    @Mock
+    private StudyRoomExitService studyRoomExitService;
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(studyRoomApiController).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    private String toJsonString(Object object) throws JsonProcessingException {
+        return this.objectMapper.writeValueAsString(object);
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/rooms api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void createRoomTest() throws Exception {
+        //given
+        int memberSequenceId = 1;
+        String roomName = "My Test Room";
+        int totalParticipantsNumber = 10;
+
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+
+        RoomCreateRequest roomCreateRequest = new RoomCreateRequest(roomName, totalParticipantsNumber);
+
+        StudyRoom mockStudyRoom = StudyRoom.builder()
+                .roomId(1)
+                .roomName(roomName)
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(0)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(memberSequenceId)
+                .maxParticipants(totalParticipantsNumber)
+                .build();
+
+        given(studyRoomService.createRoom(roomName, totalParticipantsNumber, memberSequenceId))
+                .willReturn(mockStudyRoom);
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rooms")
+                        .session(httpSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJsonString(roomCreateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(mockStudyRoom.getRoomId()))
+                .andExpect(jsonPath("$.roomName").value(mockStudyRoom.getRoomName()))
+                .andExpect(jsonPath("$.maxParticipants").value(mockStudyRoom.getMaxParticipants()))
+                .andExpect(jsonPath("$.currentParticipants").value(mockStudyRoom.getCurrentParticipants()))
+                .andExpect(jsonPath("$.roomManagerSequenceId").value(mockStudyRoom.getManagerSequenceId()))
+                .andDo(print());
+
+        verify(studyRoomService, Mockito.times(1)).createRoom(roomName, totalParticipantsNumber, memberSequenceId);
+    }
+    
+    @Test
+    @DisplayName("POST /api/v1/rooms 주어진 매개 변수 형식이 잘못된 경우 결과로 BAD REQUEST, InvalidFormatException 반환")
+    void createRoomMethodInvalidParameterFormatTest() throws Exception {
+        //given
+        int memberSequenceId = 1;
+        String roomName = "My Test Room";
+        String wrongValue = "cannotConvertToIntValue";
+
+        String json = "{\"roomName\":\"" + roomName +"\",\"total\":\"" + wrongValue +"\"}";
+
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+
+
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rooms")
+                .session(httpSession)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        result.getResolvedException().getClass().isAssignableFrom(InvalidFormatException.class))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rooms api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void roomEnterTest() throws Exception {
+        //given
+        int roomId = 1;
+        int memberSequenceId = 1;
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+
+        StudyRoom mockStudyRoom = StudyRoom.builder()
+                .roomId(1)
+                .roomName("My Test Room")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(2)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(memberSequenceId)
+                .maxParticipants(10)
+                .build();
+
+        given(studyRoomService.enterRoom(anyInt(), anyInt()))
+                .willReturn(mockStudyRoom);
+
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/api/v1/rooms")
+                        .param("roomId", String.valueOf(roomId))
+                        .session(httpSession)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(mockStudyRoom.getRoomId()))
+                .andExpect(jsonPath("$.roomName").value(mockStudyRoom.getRoomName()))
+                .andExpect(jsonPath("$.maxParticipants").value(mockStudyRoom.getMaxParticipants()))
+                .andExpect(jsonPath("$.currentParticipants").value(mockStudyRoom.getCurrentParticipants()))
+                .andExpect(jsonPath("$.roomManagerSequenceId").value(mockStudyRoom.getManagerSequenceId()))
+                .andDo(print());
+
+        verify(studyRoomService, Mockito.times(1)).enterRoom(1,1);
+    }
+    
+    @Test
+    @DisplayName("GET /api/v1/rooms 주어진 매개 변수 형식이 잘못된 경우 결과로 BAD REQUEST, InvalidFormatException 반환")
+    void enterRoomMethodInvalidParameterFormatTest() throws Exception {
+        //given
+        String invalidFormatRoomId = "cannotConvertToIntValue";
+        int memberSequenceId = 1;
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+        
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rooms")
+                        .session(httpSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("roomId", invalidFormatRoomId))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        result.getResolvedException().getClass().isAssignableFrom(InvalidFormatException.class))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/rooms api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void exitRoomTest() throws Exception {
+        //given
+        int roomId = 1;
+        int memberSequenceId = 1;
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+
+        StudyRoom mockStudyRoom = StudyRoom.builder()
+                .roomId(1)
+                .roomName("My Test Room")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(2)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(memberSequenceId)
+                .maxParticipants(10)
+                .build();
+
+        given(studyRoomExitService.exitRoom(anyInt(), anyInt()))
+                .willReturn(mockStudyRoom);
+
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete("/api/v1/rooms")
+                        .param("roomId", String.valueOf(roomId))
+                        .session(httpSession)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(mockStudyRoom.getRoomId()))
+                .andExpect(jsonPath("$.roomName").value(mockStudyRoom.getRoomName()))
+                .andExpect(jsonPath("$.maxParticipants").value(mockStudyRoom.getMaxParticipants()))
+                .andExpect(jsonPath("$.currentParticipants").value(mockStudyRoom.getCurrentParticipants()))
+                .andExpect(jsonPath("$.roomManagerSequenceId").value(mockStudyRoom.getManagerSequenceId()))
+                .andDo(print());
+
+        verify(studyRoomExitService,
+                Mockito.times(1)).exitRoom(mockStudyRoom.getRoomId(), memberSequenceId);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/v1/rooms 주어진 매개 변수 형식이 잘못된 경우 결과로 BAD REQUEST, InvalidFormatException 반환")
+    void exitRoomMethodInvalidParameterFormatTest() throws Exception {
+        //given
+        String invalidFormatRoomId = "cannotConvertToIntValue";
+        int memberSequenceId = 1;
+        MockHttpSession httpSession = new MockHttpSession();
+        httpSession.setAttribute("seq_id", memberSequenceId);
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/rooms")
+                        .session(httpSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("roomId", invalidFormatRoomId))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        result.getResolvedException().getClass().isAssignableFrom(InvalidFormatException.class))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rooms/activated api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void getActivatedStudyRoomsTest() throws Exception {
+        //given
+        StudyRoom mockStudyRoom1 = StudyRoom.builder()
+                .roomId(1)
+                .roomName("My Test Room")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(2)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(1)
+                .maxParticipants(10)
+                .build();
+
+        StudyRoom mockStudyRoom2 = StudyRoom.builder()
+                .roomId(2)
+                .roomName("My Test Room2")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(3)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(4)
+                .maxParticipants(15)
+                .build();
+
+        List<StudyRoom> studyRooms = List.of(mockStudyRoom1, mockStudyRoom2);
+
+        given(studyRoomService.getActivatedStudyRooms())
+                .willReturn(studyRooms);
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rooms/activated"));
+
+        // then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(studyRoomService, Mockito.times(1)).getActivatedStudyRooms();
+
+        //System.out.println("mvc result :" + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rooms/info api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void getEnterAvailableStudyRoomsTest() throws Exception {
+        //given
+        StudyRoom mockStudyRoom1 = StudyRoom.builder()
+                .roomId(1)
+                .roomName("My Test Room")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(2)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(1)
+                .maxParticipants(10)
+                .build();
+
+        StudyRoom mockStudyRoom2 = StudyRoom.builder()
+                .roomId(2)
+                .roomName("My Test Room2")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(3)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(4)
+                .maxParticipants(15)
+                .build();
+
+        List<StudyRoom> studyRooms = List.of(mockStudyRoom1, mockStudyRoom2);
+
+        given(studyRoomService.getEnterAvailableStudyRooms())
+                .willReturn(studyRooms);
+
+        //when
+        ResultActions resultActions =
+                mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rooms/enter-available"));
+
+        //then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(studyRoomService, Mockito.times(1)).getEnterAvailableStudyRooms();
+
+        //System.out.println("mvc result :" + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rooms/info api 메서드 호출 확인, http 응답 확인, 서비스 레이어의 비즈니스 로직 호출 확인 테스트")
+    void getRoomInfoTest() throws Exception {
+        //given
+        int roomId = 1;
+
+        StudyRoom mockStudyRoom = StudyRoom.builder()
+                .roomId(1)
+                .roomName("My Test Room")
+                .createDate(LocalDate.of(2023, 2, 25))
+                .currentParticipants(2)
+                .activateStatus(StudyRoom.ActivateStatus.ACTIVATED)
+                .managerSequenceId(1)
+                .maxParticipants(10)
+                .build();
+
+        given(studyRoomService.getRoomInformation(roomId))
+                .willReturn(mockStudyRoom);
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rooms/info")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .param("roomId", String.valueOf(roomId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roomId").value(mockStudyRoom.getRoomId()))
+                .andExpect(jsonPath("$.roomName").value(mockStudyRoom.getRoomName()))
+                .andExpect(jsonPath("$.maxParticipants").value(mockStudyRoom.getMaxParticipants()))
+                .andExpect(jsonPath("$.currentParticipants").value(mockStudyRoom.getCurrentParticipants()))
+                .andExpect(jsonPath("$.roomManagerSequenceId").value(mockStudyRoom.getManagerSequenceId()))
+                .andDo(print());
+
+        verify(studyRoomService, Mockito.times(1)).getRoomInformation(roomId);
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/rooms/info 주어진 매개 변수 형식이 잘못된 경우 결과로 BAD REQUEST, InvalidFormatException 반환")
+    void getRoomInfoMethodInvalidParameterFormatTest() throws Exception {
+        //given
+        String invalidFormatRoomId = "cannotConvertToIntValue";
+
+        //when, then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rooms/info")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("roomId", invalidFormatRoomId))
+                .andExpect(status().isBadRequest())
+                .andExpect(result ->
+                        result.getResolvedException().getClass().isAssignableFrom(InvalidFormatException.class));
+
+    }
+}


### PR DESCRIPTION
> **Controller의 책임 범위에 따른 테스트 수행**
> - Http 클라이언트의 요청을 MockMvc 사용을 통해 모방함으로써 컨트롤러 테스트.
> - 다른 의존성이 없는 StandAlone 테스트 수행.
### Controller 책임 범위
1. Http 요청을 받고 Http 응답을 내보냄
2. Http 요청의 input data를 deserialize
3. 서비스 레이어의 비즈니스 로직 호출
4. input data 검증
5. http 응답으로 deserialize

### 테스트 내용
1. controller가 해당 url을 잘 listen 하는지 확인
2. input 이 원하는 java object로 serialization 되는지 확인
3. input validation check가 잘 동작하는지 확인
4. 예상한대로 비즈니스 로직이 불렸는지 확인
5. http 응답 본문에 json 형태의 유효한 값이 포함되어있는지 확인

