### PR TITLE
[#75] Member 도메인 클래스 리팩토링 및 테스트 코드 추가

### DIFF
--- a/src/main/java/dev/flab/studytogether/domain/member/entity/Member.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/entity/Member.java
@@ -30,5 +30,9 @@ public class Member {
     public static Member createWithSequenceId(int sequenceId, String id, String password, String nickname) {
         return new Member(sequenceId, id, password, nickname);
     }
+
+    public boolean isPasswordMatched(String password) {
+        return this.password.equals(password);
+    }
     
 }

--- a/src/main/java/dev/flab/studytogether/domain/member/service/MemberService.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/service/MemberService.java
@@ -6,8 +6,6 @@ import dev.flab.studytogether.domain.member.exception.PasswordMismatchException;
 import dev.flab.studytogether.domain.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
-
 @Service
 public class MemberService {
 
@@ -22,10 +20,11 @@ public class MemberService {
         return memberRepository.save(Member.createWithoutSequenceId(id, password, nickname));
     }
 
-    public Member login(String id, String pw){
-        Member member = memberRepository.findByID(id).orElseThrow(()-> new MemberNotFoundException("일치하는 ID가 없습니다."));
+    public Member login(String id, String password){
+        Member member = memberRepository.findByID(id)
+                        .orElseThrow(()-> new MemberNotFoundException("일치하는 ID가 없습니다."));
 
-        if(member.getPassword().equals(pw)){
+        if(member.isPasswordMatched(password)){
             return member;
         }
 

--- a/src/test/java/dev/flab/studytogether/domain/member/entity/MemberTest.java
+++ b/src/test/java/dev/flab/studytogether/domain/member/entity/MemberTest.java
@@ -1,0 +1,40 @@
+package dev.flab.studytogether.domain.member.entity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("Password가 일치하면 true를 반환한다.")
+    void whenPasswordMatchesThenReturnTrue() {
+        //given
+        String id = "testID";
+        String password = "testPW";
+        String nickname = "testNickName";
+
+        Member member = Member.createWithoutSequenceId(id, password, nickname);
+
+        //when, then
+        assertTrue(member.isPasswordMatched(password));
+    }
+
+    @Test
+    @DisplayName("Password가 일치하지 않으면 false를 반환한다.")
+    void whenPasswordDoesNotMatchesThenReturnFalse() {
+        //given
+        String id = "testID";
+        String password = "testPW";
+        String nickname = "testNickName";
+
+        Member member = Member.createWithoutSequenceId(id, password, nickname);
+
+        String differentPassword = "differentPassword";
+
+        //when, then
+        assertFalse(member.isPasswordMatched(differentPassword));
+    }
+
+}


### PR DESCRIPTION
- 기존에 MemberService에 있던 비밀번호 일치 여부를 확인하는 로직을 Member 도메인 클래스로 이동시킴으로써, 도메인 클래스가 자신의 역할을 더욱 수행하도록 리팩토링.
- 도메인 클래스가 자신의 데이터와 동작에 대한 책임을 더욱 강하게 가지고자 수정.