### PR TITLE
[#78] 문자열 응답 시 공통 응답형식이 적용되지 않는 문제 해결

### DIFF
--- a/src/main/java/dev/flab/studytogether/domain/member/controller/MemberAPIController.java
+++ b/src/main/java/dev/flab/studytogether/domain/member/controller/MemberAPIController.java
@@ -61,8 +61,11 @@ public class MemberAPIController {
 
     @GetMapping("/logout")
     @Operation(summary = "logout", description = "로그아웃")
-    public void logout(HttpSession httpSession) {
-        SessionUtil.logoutMember(httpSession);
+    @ResponseStatus(HttpStatus.OK)
+    public String logout(HttpSession httpSession) {
+        SessionUtil.logoutMemebr(httpSession);
+
+        return "logged out successfully.";
     }
 
     private void setCookies(HttpServletResponse response, String id, int sequenceId) {

--- a/src/main/java/dev/flab/studytogether/handler/ApiResponseController.java
+++ b/src/main/java/dev/flab/studytogether/handler/ApiResponseController.java
@@ -11,13 +11,16 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 
 @RestControllerAdvice
-public class ApiResponseController implements ResponseBodyAdvice {
+public class ApiResponseController implements ResponseBodyAdvice<Object> {
 
     @Override
     public boolean supports(MethodParameter returnType, Class converterType) {
         ResponseStatus responseStatus = returnType.getMethodAnnotation(ResponseStatus.class);
 
-        return responseStatus != null && responseStatus.value().is2xxSuccessful();
+        return responseStatus != null &&
+                responseStatus.value().is2xxSuccessful() &&
+                returnType.getParameterType() != String.class &&
+                MappingJackson2MessageConverter.class.isAssignableFrom(converterType);
     }
 
     @Override

--- a/src/main/java/dev/flab/studytogether/handler/CustomStringHttpMessageConverter.java
+++ b/src/main/java/dev/flab/studytogether/handler/CustomStringHttpMessageConverter.java
@@ -1,0 +1,50 @@
+package dev.flab.studytogether.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.flab.studytogether.response.ApiResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CustomStringHttpMessageConverter extends AbstractHttpMessageConverter<String> {
+    private final ObjectMapper objectMapper;
+
+    public CustomStringHttpMessageConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<MediaType> getSupportedMediaTypes() {
+        return Collections.singletonList(MediaType.APPLICATION_JSON);
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return String.class == clazz;
+    }
+
+    @Override
+    protected String readInternal(Class<? extends String> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        return null;
+    }
+
+    @Override
+    protected void writeInternal(String s, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+        String str = this.objectMapper.writeValueAsString(ApiResponse.ok(s));
+        StreamUtils.copy(str.getBytes(StandardCharsets.UTF_8), outputMessage.getBody());
+    }
+}


### PR DESCRIPTION
### String 문자열 반환시 ClassCastException 해결

- 컨트롤러에서 String 반환시 StringHttpMessageConverter를 사용하여 응답 작성시 ClassCastException 발생.
- Custom converter 사용하여 String 반환시 컨버터에서 ApiResponse 적용하도록 수정
- 기존 ResponseBodyAdvice를 구현한 ApiResponseController supports 메서드에서 String 타입은 허용하지 않도록 수정